### PR TITLE
Fix: Standardize math delimiters in model response display

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -281,8 +281,20 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // --- Modal Functions ---
     function openModal(responseText) {
-        // Render markdown to HTML
-        const html = marked.parse(responseText);
+    // Pre-process to convert custom math delimiters to standard LaTeX delimiters
+    let processedText = responseText;
+
+    // Replace ( \latex... ) with \( \latex... \) for inline math
+    // This regex looks for an opening parenthesis, followed by optional space, a backslash (start of LaTeX),
+    // then any characters (non-greedy), and finally optional space and closing parenthesis.
+    processedText = processedText.replace(/\(\s*(\\[^)]+)\s*\)/g, '\\($1\\)');
+
+    // Replace [ \latex... ] with \[ \latex... \] for display math
+    // Similar logic for square brackets.
+    processedText = processedText.replace(/\[\s*(\\[^\]]+)\s*\]/g, '\\[$1\\]');
+
+    // Render markdown to HTML using marked.js
+    const html = marked.parse(processedText);
         modalResponseText.innerHTML = html;
         responseModal.style.display = 'block';
     }


### PR DESCRIPTION
I've preprocessed AI model responses in the JavaScript `openModal` function to convert non-standard math delimiters to standard LaTeX forms before rendering with marked.js.

Specifically, this change:
- Replaces `( \latex... )` with `\( \latex... \)`
- Replaces `[ \latex... ]` with `\[ \latex... \]`

This ensures that mathematical expressions are correctly delimited for potential future integration with math rendering engines like KaTeX or MathJax, and prevents `marked.js` from misinterpreting these specific custom delimiters. This addresses issues where model outputs with these custom delimiters were not rendering correctly.

## Resumo por Sourcery

Correções de bugs:
- Transformar trechos de LaTeX envolvidos em parênteses em delimitadores matemáticos inline \( ... \) e trechos envolvidos em colchetes em delimitadores matemáticos de exibição \[ ... \] antes de passar o conteúdo para marked.js.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Transform parentheses-wrapped LaTeX snippets into inline math delimiters \( ... \) and square-bracket-wrapped snippets into display math delimiters \[ ... \] before passing content to marked.js.

</details>